### PR TITLE
Fix install script missing cauldron functions

### DIFF
--- a/functions/cauldron_repair.fish
+++ b/functions/cauldron_repair.fish
@@ -94,7 +94,23 @@ function cauldron_repair --description "Repair broken Cauldron installation"
             set -a issues "Too few functions installed (found $func_count, expected 30+)"
             echo "  ✗ Only $func_count functions found (expected 30+)"
         else
-            echo "  ✓ Functions OK ($func_count installed)"
+            # Check for critical functions (including familiar functions)
+            set -l critical_functions ask.fish f-thinks.fish f-says.fish cauldron_update.fish cauldron_repair.fish
+            set -l missing_functions ()
+
+            for func in $critical_functions
+                if not test -f "$functions_dir/$func"
+                    set -a missing_functions $func
+                end
+            end
+
+            if test (count $missing_functions) -gt 0
+                set issues_found (math $issues_found + 1)
+                set -a issues "Missing critical functions: "(string join ", " $missing_functions)
+                echo "  ✗ Missing critical functions: "(string join ", " $missing_functions)
+            else
+                echo "  ✓ Functions OK ($func_count installed)"
+            end
         end
     end
 
@@ -211,6 +227,16 @@ function cauldron_repair --description "Repair broken Cauldron installation"
             if test -f "$func_file"
                 cp -f "$func_file" "$functions_dir/"
                 set copied_count (math $copied_count + 1)
+            end
+        end
+
+        # Copy familiar directory functions if they exist
+        if test -d "$CAULDRON_PATH/familiar"
+            for func_file in "$CAULDRON_PATH"/familiar/*.fish
+                if test -f "$func_file"
+                    cp -f "$func_file" "$functions_dir/"
+                    set copied_count (math $copied_count + 1)
+                end
             end
         end
 

--- a/install.sh
+++ b/install.sh
@@ -339,9 +339,32 @@ verify_installation() {
     fi
 
     # Check function count
-    local func_count=$(find "$CAULDRON_CONFIG_DIR/functions" -name "*.fish" | wc -l)
+    local func_count=$(find "$CAULDRON_CONFIG_DIR/functions" -name "*.fish" 2>/dev/null | wc -l)
     if [ "$func_count" -lt 10 ]; then
         errors+=("Too few functions installed (found $func_count)")
+    fi
+
+    # Check for critical functions (including familiar functions)
+    local critical_functions=("ask.fish" "f-thinks.fish" "f-says.fish" "cauldron_update.fish" "cauldron_repair.fish")
+    local missing_functions=()
+
+    for func in "${critical_functions[@]}"; do
+        if [ ! -f "$CAULDRON_CONFIG_DIR/functions/$func" ]; then
+            missing_functions+=("$func")
+        fi
+    done
+
+    if [ ${#missing_functions[@]} -ne 0 ]; then
+        errors+=("Missing critical functions: ${missing_functions[*]}")
+    fi
+
+    # Check data files
+    if [ ! -f "$CAULDRON_CONFIG_DIR/data/palettes.json" ]; then
+        errors+=("palettes.json not found")
+    fi
+
+    if [ ! -f "$CAULDRON_CONFIG_DIR/data/spinners.json" ]; then
+        errors+=("spinners.json not found")
     fi
 
     if [ ${#errors[@]} -ne 0 ]; then
@@ -352,7 +375,7 @@ verify_installation() {
         exit 1
     fi
 
-    success "Installation verified"
+    success "Installation verified ($func_count functions installed)"
 }
 
 # Print success message


### PR DESCRIPTION
Previously, cauldron_repair did not copy functions from the familiar/ directory (f-thinks, f-says, etc.), causing errors when users ran `cauldron_repair --fix-all` after installation.

Changes:
- cauldron_repair.fish: Copy familiar/ directory functions during repair
- cauldron_repair.fish: Check for critical functions in verification
- install.sh: Add verification for critical functions including f-thinks
- install.sh: Add verification for required data files
- install.sh: Show function count in success message

Fixes issue where f-thinks command was not found after fresh install or repair, even though cauldron_repair reported "Functions OK".