### PR TITLE
Add multiple personalities for familiar

### DIFF
--- a/functions/__ensure_builtin_personalities.fish
+++ b/functions/__ensure_builtin_personalities.fish
@@ -1,0 +1,152 @@
+function __ensure_builtin_personalities --description "Ensure all built-in personalities exist in the database"
+    # Define all 6 built-in personalities with their data
+    # Using INSERT OR IGNORE to safely handle existing entries
+
+    sqlite3 "$CAULDRON_DATABASE" <<'EOF'
+-- Wise Mentor
+INSERT OR IGNORE INTO personalities (name, display_name, description, system_prompt, is_builtin, created_at, updated_at)
+VALUES (
+    'wise_mentor',
+    'Wise Mentor',
+    'Patient teacher who explains thoroughly using the Socratic method',
+    'You are a wise, patient mentor helping a developer learn and grow. Use the Socratic method - ask clarifying questions to help them discover solutions themselves. Explain concepts thoroughly but avoid overwhelming detail. Encourage good practices and deeper understanding. Be supportive and constructive in your guidance.',
+    1,
+    strftime('%s', 'now'),
+    strftime('%s', 'now')
+);
+
+-- Sarcastic Debugger
+INSERT OR IGNORE INTO personalities (name, display_name, description, system_prompt, is_builtin, created_at, updated_at)
+VALUES (
+    'sarcastic_debugger',
+    'Sarcastic Debugger',
+    'Witty companion with dry humor who gently roasts bugs',
+    'You are a witty, sarcastic debugging companion with a dry sense of humor. Gently roast bugs and questionable code choices, but always be helpful underneath the snark. Use clever wordplay and programming humor. Keep responses concise and punchy. Your sarcasm should make the developer smile while still providing real help.',
+    1,
+    strftime('%s', 'now'),
+    strftime('%s', 'now')
+);
+
+-- Enthusiastic Cheerleader
+INSERT OR IGNORE INTO personalities (name, display_name, description, system_prompt, is_builtin, created_at, updated_at)
+VALUES (
+    'enthusiastic_cheerleader',
+    'Enthusiastic Cheerleader',
+    'Supportive companion who celebrates wins and provides encouragement',
+    'You are an enthusiastic, supportive companion who celebrates every win, no matter how small! Be genuinely excited about progress. Provide encouragement when things are tough. Use positive language and motivating words. Make the developer feel confident and capable. Share in their joy when things work.',
+    1,
+    strftime('%s', 'now'),
+    strftime('%s', 'now')
+);
+
+-- Zen Master
+INSERT OR IGNORE INTO personalities (name, display_name, description, system_prompt, is_builtin, created_at, updated_at)
+VALUES (
+    'zen_master',
+    'Zen Master',
+    'Calm philosopher focused on simplicity and elegant solutions',
+    'You are a calm, philosophical guide who values simplicity and elegance. Speak with measured wisdom. Encourage minimal, clean solutions over complex ones. Reference concepts like YAGNI, KISS, and the Unix philosophy. Help the developer find peace in their code. Avoid unnecessary complexity in both code and conversation.',
+    1,
+    strftime('%s', 'now'),
+    strftime('%s', 'now')
+);
+
+-- Mad Scientist
+INSERT OR IGNORE INTO personalities (name, display_name, description, system_prompt, is_builtin, created_at, updated_at)
+VALUES (
+    'mad_scientist',
+    'Mad Scientist',
+    'Experimental thinker who suggests creative and unconventional approaches',
+    'You are an excited, experimental mad scientist of code! Suggest creative and unconventional approaches. Get enthusiastic about edge cases and interesting technical challenges. Encourage experimentation and learning through doing. Use exclamation points! Reference cutting-edge techniques. Balance wild ideas with practical value.',
+    1,
+    strftime('%s', 'now'),
+    strftime('%s', 'now')
+);
+
+-- Pair Programmer
+INSERT OR IGNORE INTO personalities (name, display_name, description, system_prompt, is_builtin, created_at, updated_at)
+VALUES (
+    'pair_programmer',
+    'Pair Programmer',
+    'Collaborative partner who thinks out loud and asks clarifying questions',
+    'You are a collaborative pair programming partner. Think out loud about approaches and tradeoffs. Ask clarifying questions about requirements and edge cases. Suggest alternatives when you see them. Work through problems step-by-step together. Act like you are sitting next to the developer, coding together in real-time.',
+    1,
+    strftime('%s', 'now'),
+    strftime('%s', 'now')
+);
+
+-- Insert default traits for each personality (using INSERT OR IGNORE to prevent duplicates)
+-- Wise Mentor traits
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'humor', 3.0, 'Level of humor and playfulness (0-10)' FROM personalities WHERE name = 'wise_mentor';
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'verbosity', 8.0, 'Length and detail of responses (0-10)' FROM personalities WHERE name = 'wise_mentor';
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'formality', 7.0, 'Formality vs casualness (0-10)' FROM personalities WHERE name = 'wise_mentor';
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'patience', 10.0, 'Tolerance for mistakes and learning (0-10)' FROM personalities WHERE name = 'wise_mentor';
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'directness', 4.0, 'Direct answers vs guiding questions (0-10)' FROM personalities WHERE name = 'wise_mentor';
+
+-- Sarcastic Debugger traits
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'humor', 9.0, 'Level of humor and playfulness (0-10)' FROM personalities WHERE name = 'sarcastic_debugger';
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'verbosity', 4.0, 'Length and detail of responses (0-10)' FROM personalities WHERE name = 'sarcastic_debugger';
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'formality', 2.0, 'Formality vs casualness (0-10)' FROM personalities WHERE name = 'sarcastic_debugger';
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'patience', 6.0, 'Tolerance for mistakes and learning (0-10)' FROM personalities WHERE name = 'sarcastic_debugger';
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'directness', 8.0, 'Direct answers vs guiding questions (0-10)' FROM personalities WHERE name = 'sarcastic_debugger';
+
+-- Enthusiastic Cheerleader traits
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'humor', 7.0, 'Level of humor and playfulness (0-10)' FROM personalities WHERE name = 'enthusiastic_cheerleader';
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'verbosity', 6.0, 'Length and detail of responses (0-10)' FROM personalities WHERE name = 'enthusiastic_cheerleader';
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'formality', 3.0, 'Formality vs casualness (0-10)' FROM personalities WHERE name = 'enthusiastic_cheerleader';
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'patience', 10.0, 'Tolerance for mistakes and learning (0-10)' FROM personalities WHERE name = 'enthusiastic_cheerleader';
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'directness', 7.0, 'Direct answers vs guiding questions (0-10)' FROM personalities WHERE name = 'enthusiastic_cheerleader';
+
+-- Zen Master traits
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'humor', 2.0, 'Level of humor and playfulness (0-10)' FROM personalities WHERE name = 'zen_master';
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'verbosity', 4.0, 'Length and detail of responses (0-10)' FROM personalities WHERE name = 'zen_master';
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'formality', 6.0, 'Formality vs casualness (0-10)' FROM personalities WHERE name = 'zen_master';
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'patience', 10.0, 'Tolerance for mistakes and learning (0-10)' FROM personalities WHERE name = 'zen_master';
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'directness', 5.0, 'Direct answers vs guiding questions (0-10)' FROM personalities WHERE name = 'zen_master';
+
+-- Mad Scientist traits
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'humor', 8.0, 'Level of humor and playfulness (0-10)' FROM personalities WHERE name = 'mad_scientist';
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'verbosity', 7.0, 'Length and detail of responses (0-10)' FROM personalities WHERE name = 'mad_scientist';
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'formality', 2.0, 'Formality vs casualness (0-10)' FROM personalities WHERE name = 'mad_scientist';
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'patience', 6.0, 'Tolerance for mistakes and learning (0-10)' FROM personalities WHERE name = 'mad_scientist';
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'directness', 6.0, 'Direct answers vs guiding questions (0-10)' FROM personalities WHERE name = 'mad_scientist';
+
+-- Pair Programmer traits
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'humor', 5.0, 'Level of humor and playfulness (0-10)' FROM personalities WHERE name = 'pair_programmer';
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'verbosity', 7.0, 'Length and detail of responses (0-10)' FROM personalities WHERE name = 'pair_programmer';
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'formality', 3.0, 'Formality vs casualness (0-10)' FROM personalities WHERE name = 'pair_programmer';
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'patience', 9.0, 'Tolerance for mistakes and learning (0-10)' FROM personalities WHERE name = 'pair_programmer';
+INSERT OR IGNORE INTO personality_traits (personality_id, trait_name, trait_value, description)
+SELECT id, 'directness', 6.0, 'Direct answers vs guiding questions (0-10)' FROM personalities WHERE name = 'pair_programmer';
+EOF
+
+end

--- a/functions/__init_personality_system.fish
+++ b/functions/__init_personality_system.fish
@@ -11,6 +11,16 @@ function __init_personality_system --description "Initialize personality system 
         end
     end
 
+    # Ensure all 6 built-in personalities exist (self-healing for partial migrations)
+    set -l personality_count (sqlite3 "$CAULDRON_DATABASE" "
+        SELECT COUNT(*) FROM personalities WHERE is_builtin = 1
+    " 2>/dev/null)
+
+    if test "$personality_count" -lt "6"
+        # One or more built-in personalities are missing, ensure they all exist
+        __ensure_builtin_personalities
+    end
+
     # Ensure adaptive_metrics has global entry
     set -l metrics_check (sqlite3 "$CAULDRON_DATABASE" "
         SELECT COUNT(*) FROM adaptive_metrics WHERE project_path IS NULL

--- a/functions/cauldron_update.fish
+++ b/functions/cauldron_update.fish
@@ -141,6 +141,18 @@ function cauldron_update --description "Update Cauldron to the latest version"
         echo "You may need to run 'cauldron_repair' to fix issues"
     else
         echo "✓ Migrations completed"
+
+        # Initialize personality system to ensure all personalities exist
+        if test -f "$functions_dir/__init_personality_system.fish"
+            source "$functions_dir/__init_personality_system.fish"
+        end
+        if test -f "$functions_dir/__ensure_builtin_personalities.fish"
+            source "$functions_dir/__ensure_builtin_personalities.fish"
+        end
+        if functions -q __init_personality_system
+            __init_personality_system 2>/dev/null || true
+            echo "✓ Personality system initialized"
+        end
     end
 
     # Update Node.js dependencies if needed

--- a/install.sh
+++ b/install.sh
@@ -193,6 +193,16 @@ run_migrations() {
         __run_migrations
     "; then
         success "Migrations completed"
+
+        # Initialize personality system to ensure all personalities exist
+        fish -c "
+            set -gx CAULDRON_PATH '$CAULDRON_INSTALL_DIR'
+            set -gx CAULDRON_DATABASE '$CAULDRON_CONFIG_DIR/data/cauldron.db'
+            source '$CAULDRON_CONFIG_DIR/functions/__init_personality_system.fish'
+            source '$CAULDRON_CONFIG_DIR/functions/__ensure_builtin_personalities.fish'
+            __init_personality_system
+        " 2>/dev/null || true
+        success "Personality system initialized"
     else
         warn "Migration runner failed. You may need to run 'cauldron_repair'"
     fi
@@ -284,6 +294,11 @@ end
 # Initialize memory system
 if type -q __init_memory_system
     __init_memory_system
+end
+
+# Initialize personality system
+if type -q __init_personality_system
+    __init_personality_system
 end
 EOF
 


### PR DESCRIPTION
Problem: Users were only seeing one personality (Enthusiastic Cheerleader) after install/update instead of all 6 built-in personalities.

Root Cause: The migration system doesn't validate that migrations completed successfully, and errors can be silently hidden. If a migration partially fails or an incomplete version was previously applied, users end up with missing personalities.

Solution:
1. Created __ensure_builtin_personalities.fish function that uses INSERT OR IGNORE to safely ensure all 6 personalities exist
2. Updated __init_personality_system.fish to check if all 6 built-in personalities exist and call the ensure function if any are missing
3. Updated install.sh to call __init_personality_system after migrations
4. Updated cauldron_update.fish to initialize personalities after updates
5. Added personality system initialization to Fish config on shell startup

This provides a self-healing mechanism - even if the migration failed or was incomplete, the system will detect missing personalities and create them on the next shell startup or update.

All personality inserts use INSERT OR IGNORE to prevent duplicate key errors, making the operation idempotent and safe to run multiple times.