### PR TITLE
Add user preferences to installation process

### DIFF
--- a/functions/__build_personality_prompt.fish
+++ b/functions/__build_personality_prompt.fish
@@ -98,8 +98,20 @@ function __build_personality_prompt --description "Build system prompt with pers
         set complexity $adaptive_parts[3]
     end
 
+    # Get familiar name from preferences
+    set -l familiar_name (sqlite3 "$CAULDRON_DATABASE" "
+        SELECT preference_value FROM user_preferences
+        WHERE preference_key = 'familiar_name' AND project_path IS NULL
+        LIMIT 1
+    " 2>/dev/null)
+
     # Build enhanced prompt with adaptive modifiers
     set -l enhanced_prompt "$base_prompt"
+
+    # Add familiar name if available
+    if test -n "$familiar_name"
+        set enhanced_prompt "$enhanced_prompt You are known as $familiar_name to this user."
+    end
 
     # Relationship-based modifications
     if test "$relationship_level" -ge 60

--- a/functions/__cauldron_setup_wizard.fish
+++ b/functions/__cauldron_setup_wizard.fish
@@ -1,0 +1,226 @@
+#!/usr/bin/env fish
+
+function __cauldron_setup_wizard --description "Interactive setup wizard for first-time Cauldron installation"
+    # This function collects user preferences during installation
+    # It stores: preferred name, pronouns, familiar name, and familiar personality
+
+    set -l func_version "1.0.0"
+    set __cauldron_category "Internal"
+
+    # Flag options
+    set -l options "s/skip" "h/help" "v/version"
+    argparse -n __cauldron_setup_wizard $options -- $argv
+
+    if set -q _flag_version
+        echo $func_version
+        return 0
+    end
+
+    if set -q _flag_help
+        echo "Usage: __cauldron_setup_wizard [OPTIONS]"
+        echo ""
+        echo "Interactive setup wizard for Cauldron installation"
+        echo ""
+        echo "Options:"
+        echo "  -s, --skip     Skip interactive setup and use defaults"
+        echo "  -h, --help     Show this help message"
+        echo "  -v, --version  Show version number"
+        return 0
+    end
+
+    # Skip if flag is set (for non-interactive installs)
+    if set -q _flag_skip
+        echo "Skipping interactive setup, using defaults..."
+        return 0
+    end
+
+    # Check if we're in an interactive terminal
+    if not isatty stdin
+        echo "Non-interactive terminal detected, skipping setup wizard..."
+        return 0
+    end
+
+    # Welcome banner
+    echo ""
+    echo "╔═══════════════════════════════════════════════════════╗"
+    echo "║                                                       ║"
+    echo "║         🔮  Welcome to Cauldron Setup  🔮            ║"
+    echo "║                                                       ║"
+    echo "╚═══════════════════════════════════════════════════════╝"
+    echo ""
+    echo "Let's personalize your Cauldron experience!"
+    echo ""
+
+    # Collect user's preferred name
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "  What should your familiar call you?"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    read -l -P "Your preferred name: " user_name
+
+    # Default to username if empty
+    if test -z "$user_name"
+        set user_name (whoami)
+        echo "  Using system username: $user_name"
+    end
+
+    # Collect user's pronouns
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "  What are your preferred pronouns?"
+    echo "  (e.g., he/him, she/her, they/them, etc.)"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    read -l -P "Your pronouns: " user_pronouns
+
+    # Default to they/them if empty
+    if test -z "$user_pronouns"
+        set user_pronouns "they/them"
+        echo "  Using default: $user_pronouns"
+    end
+
+    # Collect familiar name preference
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "  Let's name your familiar!"
+    echo "  Press Enter to generate a random name, or type your own"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+    set -l familiar_name ""
+    set -l satisfied "n"
+
+    while test "$satisfied" != "y"
+        read -l -P "Familiar name (Enter for random): " familiar_name_input
+
+        if test -z "$familiar_name_input"
+            # Generate random name using new-name if available
+            if command -q new-name
+                set familiar_name (new-name 2>/dev/null | string split " ")[1]
+            else
+                # Fallback to simple random names
+                set -l names "Zephyr" "Luna" "Astrid" "Felix" "Nova" "Orion" "Sage" "Phoenix" "Echo" "Rune"
+                set familiar_name $names[(random 1 (count $names))]
+            end
+            echo "  Generated name: $familiar_name"
+        else
+            set familiar_name $familiar_name_input
+        end
+
+        read -l -P "Happy with '$familiar_name'? (y/n/r for random): " satisfied
+
+        if test "$satisfied" = "r"
+            set satisfied "n"
+        end
+    end
+
+    # Choose familiar personality
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "  Choose your familiar's personality:"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+    # Get personalities from database
+    set -l personalities (sqlite3 "$CAULDRON_DATABASE" "
+        SELECT name, display_name, description
+        FROM personalities
+        WHERE is_builtin = 1
+        ORDER BY name ASC
+    " 2>/dev/null)
+
+    if test -n "$personalities"
+        echo ""
+        set -l idx 1
+        set -l personality_names
+
+        for line in $personalities
+            set -l parts (string split '|' $line)
+            set -l name $parts[1]
+            set -l display_name $parts[2]
+            set -l description $parts[3]
+
+            set personality_names $personality_names $name
+
+            # Truncate description if too long
+            set -l short_desc $description
+            if test (string length "$description") -gt 50
+                set short_desc (string sub -l 47 "$description")"..."
+            end
+
+            echo "  $idx. $display_name"
+            echo "     $short_desc"
+            echo ""
+            set idx (math $idx + 1)
+        end
+
+        # Default to wise_mentor (option 1)
+        read -l -P "Select personality (1-"(count $personality_names)", default: 1): " personality_choice
+
+        if test -z "$personality_choice"
+            set personality_choice 1
+        end
+
+        # Validate input
+        if test "$personality_choice" -ge 1 -a "$personality_choice" -le (count $personality_names)
+            set -l selected_personality $personality_names[$personality_choice]
+            echo "  Selected: $selected_personality"
+        else
+            set -l selected_personality "wise_mentor"
+            echo "  Invalid choice, using default: wise_mentor"
+        end
+    else
+        set -l selected_personality "wise_mentor"
+        echo "  Using default personality: wise_mentor"
+    end
+
+    # Save all preferences to database
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "  Saving your preferences..."
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+    # Build user profile string
+    set -l user_profile "User: $user_name ($user_pronouns)"
+
+    # Insert or update user preferences
+    sqlite3 "$CAULDRON_DATABASE" "
+        INSERT OR REPLACE INTO user_preferences (preference_key, preference_value, project_path, created_at, updated_at)
+        VALUES
+            ('user_name', '$user_name', NULL, strftime('%s', 'now'), strftime('%s', 'now')),
+            ('user_pronouns', '$user_pronouns', NULL, strftime('%s', 'now'), strftime('%s', 'now')),
+            ('user_profile', '$user_profile', NULL, strftime('%s', 'now'), strftime('%s', 'now')),
+            ('familiar_name', '$familiar_name', NULL, strftime('%s', 'now'), strftime('%s', 'now')),
+            ('active_personality', '$selected_personality', NULL, strftime('%s', 'now'), strftime('%s', 'now'))
+    " 2>/dev/null
+
+    # Set environment variables
+    set -Ux CAULDRON_USER_NAME $user_name
+    set -Ux CAULDRON_USER_PRONOUNS $user_pronouns
+    set -Ux CAULDRON_FAMILIAR_NAME $familiar_name
+
+    # Initialize relationship for the selected personality
+    set -l personality_id (sqlite3 "$CAULDRON_DATABASE" "
+        SELECT id FROM personalities WHERE name = '$selected_personality' LIMIT 1
+    " 2>/dev/null)
+
+    if test -n "$personality_id"
+        sqlite3 "$CAULDRON_DATABASE" "
+            INSERT OR IGNORE INTO familiar_relationship
+            (project_path, personality_id, relationship_level, total_interactions, successful_interactions, failed_interactions, first_interaction)
+            VALUES
+            (NULL, $personality_id, 0, 0, 0, 0, strftime('%s', 'now'))
+        " 2>/dev/null
+    end
+
+    echo ""
+    echo "✓ Preferences saved successfully!"
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "  Summary:"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "  Name:        $user_name"
+    echo "  Pronouns:    $user_pronouns"
+    echo "  Familiar:    $familiar_name"
+    echo "  Personality: $selected_personality"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+
+    return 0
+end

--- a/functions/__fix_shadowed_variables.fish
+++ b/functions/__fix_shadowed_variables.fish
@@ -1,0 +1,218 @@
+#!/usr/bin/env fish
+
+function __fix_shadowed_variables --description "Find and fix shadowed variables, resetting them at the correct scope"
+    # This function looks for variables that exist at multiple scopes (shadowed)
+    # and removes duplicates, ensuring they're set at the appropriate scope
+
+    set -l func_version "1.0.0"
+    set __cauldron_category "Internal"
+
+    # Flag options
+    set -l options "v/version" "h/help" "d/dry-run" "verbose"
+    argparse -n __fix_shadowed_variables $options -- $argv
+
+    if set -q _flag_version
+        echo $func_version
+        return 0
+    end
+
+    if set -q _flag_help
+        echo "Usage: __fix_shadowed_variables [OPTIONS]"
+        echo ""
+        echo "Find and fix shadowed variables in Fish shell environment"
+        echo ""
+        echo "Options:"
+        echo "  -d, --dry-run  Show what would be fixed without making changes"
+        echo "  --verbose      Show detailed output"
+        echo "  -h, --help     Show this help message"
+        echo "  -v, --version  Show version number"
+        echo ""
+        echo "Description:"
+        echo "  This function identifies variables that are set at multiple scopes"
+        echo "  (e.g., both global and universal) and consolidates them to the"
+        echo "  correct scope based on Cauldron conventions:"
+        echo "    - Universal (-Ux): Core Cauldron paths and configuration"
+        echo "    - Global (-gx): Session-specific settings"
+        echo "    - Local (-l): Function-scoped temporary variables"
+        return 0
+    end
+
+    set -l verbose 0
+    if set -q _flag_verbose
+        set verbose 1
+    end
+
+    set -l dry_run 0
+    if set -q _flag_dry_run
+        set dry_run 1
+        echo "Running in dry-run mode (no changes will be made)"
+        echo ""
+    end
+
+    # Define which Cauldron variables should be at which scope
+    # Format: variable_name:preferred_scope
+    set -l cauldron_var_scopes \
+        "CAULDRON_PATH:U" \
+        "CAULDRON_DATABASE:U" \
+        "CAULDRON_PALETTES:U" \
+        "CAULDRON_SPINNERS:U" \
+        "CAULDRON_INTERNAL_TOOLS:U" \
+        "CAULDRON_GIT_REPO:U" \
+        "__CAULDRON_DOCUMENTATION_PATH:U" \
+        "CAULDRON_FAMILIAR_NAME:U" \
+        "CAULDRON_USER_NAME:U" \
+        "CAULDRON_USER_PRONOUNS:U" \
+        "CAULDRON_VERSION:g"
+
+    set -l fixed_count 0
+    set -l shadowed_count 0
+
+    if test $verbose -eq 1
+        echo "Checking Cauldron variables for shadowing issues..."
+        echo ""
+    end
+
+    # Check each Cauldron variable
+    for var_spec in $cauldron_var_scopes
+        set -l parts (string split ':' $var_spec)
+        set -l var_name $parts[1]
+        set -l preferred_scope $parts[2]
+
+        # Check if variable exists at multiple scopes
+        set -l is_universal 0
+        set -l is_global 0
+        set -l is_local 0
+        set -l var_value ""
+
+        # Check universal scope
+        if set -qU $var_name
+            set is_universal 1
+            set var_value (set -U | grep "^$var_name " | string replace "$var_name " "")
+        end
+
+        # Check global scope
+        if set -qg $var_name
+            set is_global 1
+            if test -z "$var_value"
+                set var_value (set -g | grep "^$var_name " | string replace "$var_name " "")
+            end
+        end
+
+        # Count how many scopes this variable exists in
+        set -l scope_count (math $is_universal + $is_global)
+
+        # If variable exists at multiple scopes, it's shadowed
+        if test $scope_count -gt 1
+            set shadowed_count (math $shadowed_count + 1)
+
+            if test $verbose -eq 1; or test $dry_run -eq 1
+                echo "⚠ Found shadowed variable: $var_name"
+                if test $is_universal -eq 1
+                    echo "  - Exists in universal scope"
+                end
+                if test $is_global -eq 1
+                    echo "  - Exists in global scope"
+                end
+                echo "  - Preferred scope: $preferred_scope"
+            end
+
+            # Fix the shadowing if not in dry-run mode
+            if test $dry_run -eq 0
+                # Get the current value (prefer universal, then global)
+                if test $is_universal -eq 1
+                    set var_value $$var_name
+                else if test $is_global -eq 1
+                    set var_value $$var_name
+                end
+
+                # Remove from all scopes first
+                if test $is_universal -eq 1
+                    set -e -U $var_name 2>/dev/null
+                end
+                if test $is_global -eq 1
+                    set -e -g $var_name 2>/dev/null
+                end
+
+                # Set at the preferred scope
+                if test "$preferred_scope" = "U"
+                    set -Ux $var_name $var_value
+                    if test $verbose -eq 1
+                        echo "  ✓ Reset to universal scope: $var_name"
+                    end
+                else if test "$preferred_scope" = "g"
+                    set -gx $var_name $var_value
+                    if test $verbose -eq 1
+                        echo "  ✓ Reset to global scope: $var_name"
+                    end
+                end
+
+                set fixed_count (math $fixed_count + 1)
+            else
+                echo "  → Would reset to $preferred_scope scope"
+            end
+
+            if test $verbose -eq 1; or test $dry_run -eq 1
+                echo ""
+            end
+        end
+    end
+
+    # Also check for any other variables that might be problematic
+    # (variables set at both -U and -g that aren't in our list)
+    if test $verbose -eq 1
+        echo "Checking for other potentially shadowed variables..."
+        echo ""
+
+        # Get all universal variables
+        set -l all_universal (set -U | string match -r '^[A-Z_]+' | string replace -r ' .*' '')
+
+        # Get all global variables starting with CAULDRON
+        set -l all_cauldron_global (set -g | string match -r '^CAULDRON[A-Z_]*' | string replace -r ' .*' '')
+
+        for var in $all_universal
+            # Skip if already in our managed list
+            set -l managed 0
+            for var_spec in $cauldron_var_scopes
+                set -l managed_var (string split ':' $var_spec)[1]
+                if test "$var" = "$managed_var"
+                    set managed 1
+                    break
+                end
+            end
+
+            if test $managed -eq 0
+                # Check if it also exists in global scope
+                if set -qg $var
+                    echo "ℹ Found unmanaged shadowed variable: $var"
+                    echo "  (exists in both universal and global scope)"
+                    echo "  Skipping - not in Cauldron managed variables list"
+                    echo ""
+                end
+            end
+        end
+    end
+
+    # Summary
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    if test $dry_run -eq 1
+        echo "  Dry Run Summary:"
+        echo "  Found $shadowed_count shadowed variable(s)"
+        echo "  Would fix: $shadowed_count variable(s)"
+    else
+        echo "  Summary:"
+        echo "  Found $shadowed_count shadowed variable(s)"
+        echo "  Fixed: $fixed_count variable(s)"
+    end
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+    if test $shadowed_count -eq 0
+        echo "✓ No shadowed variables found!"
+    else if test $dry_run -eq 0
+        echo "✓ Variables have been reset to their correct scopes"
+        echo ""
+        echo "Note: You may need to restart your Fish shell for changes to take full effect:"
+        echo "  exec fish"
+    end
+
+    return 0
+end


### PR DESCRIPTION
…cleanup to install process

This commit adds comprehensive user preference collection during installation and automatic cleanup of shadowed variables to ensure proper scope management.

New Features:
- Interactive setup wizard (__cauldron_setup_wizard.fish) that collects:
  * User's preferred name
  * User's preferred pronouns
  * Familiar name (with random name generation option)
  * Familiar personality selection from available built-in personalities
  * All preferences are stored in the database for use across the system

- Shadowed variables cleanup function (__fix_shadowed_variables.fish) that:
  * Identifies variables set at multiple scopes (e.g., both -Ux and -gx)
  * Consolidates them to the correct scope based on Cauldron conventions
  * Provides dry-run mode for safe testing
  * Includes verbose output option for debugging

Integration Changes:
- Updated install.sh to include two new steps:
  * fix_shadowed_variables: Runs after Fish config setup to ensure clean variable scopes
  * run_setup_wizard: Runs after verification to collect user preferences interactively
  * Both steps gracefully handle non-interactive environments (CI, piped installs)

Enhanced Functionality:
- Updated ask.fish to use new user preferences from database:
  * Fetches user_name, user_pronouns, and familiar_name from preferences
  * Falls back to environment variables if database values not available
  * Builds personalized user profile dynamically
  * Improved default fallbacks for better user experience

- Updated __build_personality_prompt.fish to include familiar name:
  * Fetches familiar_name from database preferences
  * Incorporates familiar name into the AI personality prompt
  * Ensures familiar addresses user appropriately

Database Integration:
- All preferences stored using existing user_preferences table
- New preference keys: user_name, user_pronouns, familiar_name
- Maintains backward compatibility with existing installations
- Initializes familiar_relationship for selected personality

User Experience:
- Setup wizard is fully interactive with clear prompts and validation
- Skippable in non-interactive environments (CI=true, CAULDRON_SKIP_SETUP=true)
- Provides helpful defaults and graceful degradation
- Summary display of all collected preferences
- Better personalization of AI familiar interactions