### PR TITLE
Fix parallelization bug in cauldron_update script

### DIFF
--- a/data/schema.sql
+++ b/data/schema.sql
@@ -6,6 +6,7 @@ CREATE TABLE "dependencies" (
 	"id"	INTEGER,
 	"name"	TEXT NOT NULL UNIQUE,
 	"version"	TEXT,
+	"date"	TEXT,
 	PRIMARY KEY("id" AUTOINCREMENT)
 );
 CREATE TABLE "familiars" (

--- a/data/update.sql
+++ b/data/update.sql
@@ -1,3 +1,6 @@
+-- Add date column to dependencies table if it doesn't exist (for parallel installation tracking)
+ALTER TABLE dependencies ADD COLUMN date TEXT;
+
 INSERT INTO "familiars" ("id", "name", "display_name", "familiar_type", "unlocked", "cow_src_ext", "nickname") VALUES ('8', 'vault-boy', NULL, 'Meme', '1', '1', NULL);
 INSERT INTO "familiars" ("id", "name", "display_name", "familiar_type", "unlocked", "cow_src_ext", "nickname") VALUES ('9', 'wheatley', NULL, 'Meme', '1', '1', NULL);
 INSERT INTO "familiars" ("id", "name", "display_name", "familiar_type", "unlocked", "cow_src_ext", "nickname") VALUES ('10', 'wilfred', NULL, 'Meme', '1', '1', NULL);


### PR DESCRIPTION
The parallel dependency installation feature added in the previous commit was trying to insert a 'date' column that didn't exist in the dependencies table schema, causing "table dependencies has no column named date" errors.

Changes:
- Added 'date' TEXT column to dependencies table in schema.sql
- Added ALTER TABLE migration in update.sql for existing databases

This fixes the errors that occurred during parallel apt/brew/snap installations.