### PR TITLE
fix: re-run migrations after cloning new repo in cauldron_update

### DIFF
--- a/update/cauldron_update.fish
+++ b/update/cauldron_update.fish
@@ -165,6 +165,16 @@ function cauldron_update -d 'Update Cauldron to the latest version'
   # Now we remove the temp folder
   rm -rf $tmp_dir
 
+  # Re-run schema and update migrations with the newly cloned files
+  # This ensures any new schema changes or migrations are applied to the restored database
+  if test -f $CAULDRON_PATH/data/schema.sql
+    sqlite3 $CAULDRON_DATABASE < $CAULDRON_PATH/data/schema.sql 2> /dev/null
+  end
+
+  if test -f $CAULDRON_PATH/data/update.sql
+    sqlite3 $CAULDRON_DATABASE < $CAULDRON_PATH/data/update.sql 2> /dev/null
+  end
+
   # List of folders with functions
   set CAULDRON_LOCAL_DIRS "alias" "cli" "config" "effects" "functions" "familiar" "internal" "setup" "text" "UI" "update"
 


### PR DESCRIPTION
The update script was only running schema.sql and update.sql from the OLD installation before cloning the new repo, which meant that new migrations (like the date column addition) were never applied to the restored database.

This commit adds a step to re-run both schema.sql and update.sql after cloning the new repo and restoring the backed-up data, ensuring all new schema changes and migrations are applied before installing dependencies.

This is critical for the parallel dependency installation feature to work correctly during updates.