### PR TITLE
fix: make dependencies table migration idempotent and add to cauldron…

### DIFF
--- a/data/update.sql
+++ b/data/update.sql
@@ -1,5 +1,5 @@
 -- Add date column to dependencies table if it doesn't exist (for parallel installation tracking)
-ALTER TABLE dependencies ADD COLUMN date TEXT;
+-- Note: This migration is handled by cauldron_update script to ensure idempotency
 
 INSERT INTO "familiars" ("id", "name", "display_name", "familiar_type", "unlocked", "cow_src_ext", "nickname") VALUES ('8', 'vault-boy', NULL, 'Meme', '1', '1', NULL);
 INSERT INTO "familiars" ("id", "name", "display_name", "familiar_type", "unlocked", "cow_src_ext", "nickname") VALUES ('9', 'wheatley', NULL, 'Meme', '1', '1', NULL);

--- a/update/cauldron_update.fish
+++ b/update/cauldron_update.fish
@@ -175,6 +175,13 @@ function cauldron_update -d 'Update Cauldron to the latest version'
     sqlite3 $CAULDRON_DATABASE < $CAULDRON_PATH/data/update.sql 2> /dev/null
   end
 
+  # Add date column to dependencies table if it doesn't exist (for parallel installation tracking)
+  # Check if the column exists before trying to add it
+  set has_date_column (sqlite3 $CAULDRON_DATABASE "PRAGMA table_info(dependencies);" | grep -c "date")
+  if test $has_date_column -eq 0
+    sqlite3 $CAULDRON_DATABASE "ALTER TABLE dependencies ADD COLUMN date TEXT;" 2> /dev/null
+  end
+
   # List of folders with functions
   set CAULDRON_LOCAL_DIRS "alias" "cli" "config" "effects" "functions" "familiar" "internal" "setup" "text" "UI" "update"
 


### PR DESCRIPTION
…_repair

The previous migration approach using ALTER TABLE would fail if the column already existed, and there was no way to safely retry the migration. This commit implements a robust, idempotent migration strategy.

Changes to cauldron_update:
- Added explicit check for 'date' column existence before running ALTER TABLE
- Uses PRAGMA table_info to safely detect if migration is needed
- Only attempts ALTER TABLE if column doesn't exist

Changes to update.sql:
- Removed direct ALTER TABLE command (now handled by scripts)
- Added comment explaining migration is handled by cauldron_update

Changes to cauldron_repair:
- Added Check 4: Verify dependencies table has 'date' column
- Added Fix 2: Update dependencies table schema if needed
- Uses same idempotent approach as cauldron_update
- Renumbered subsequent checks and fixes accordingly

This ensures users can safely run cauldron_update or cauldron_repair multiple times without errors, and the migration will be applied exactly once.